### PR TITLE
Use self-hosted Bazel cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+try-import /opt/credentials/bazel-remote-cache.rc


### PR DESCRIPTION
## What is the goal of this PR?

Speed up CI by using self-hosted remote Bazel cache

## What are the changes implemented in this PR?

Import `/opt/credentials/bazel-remote-cache.rc`which configures remote caching